### PR TITLE
trails to show tag names instead of ids + fix broken filter by tags

### DIFF
--- a/trail/serializers.py
+++ b/trail/serializers.py
@@ -3,6 +3,8 @@ from .models import Trail
 
 
 class TrailSerializer(serializers.ModelSerializer):
+    tags = serializers.StringRelatedField(many=True)
+
     class Meta:
         model = Trail
         fields = ('id', 'name', 'description', 'picture', 'location', 'latitude',

--- a/trail/views.py
+++ b/trail/views.py
@@ -20,8 +20,8 @@ class TrailViewSet(viewsets.ModelViewSet):
         # Later we can filter by the virtual column "num_tags" to make sure that we found all
         # the tags that were passed as parameters
         if tags:
-            trails = Trail.objects.filter(tag__name__in=tags)\
-                .annotate(num_tags=Count('tag')).filter(num_tags=len(tags))
+            trails = Trail.objects.filter(tags__name__in=tags)\
+                .annotate(num_tags=Count('tags')).filter(num_tags=len(tags))
         else:
             trails = Trail.objects.all()
         serializer = TrailSerializer(trails, many=True)


### PR DESCRIPTION
Using string representation of tags instead of showing ids.
Link to documentation on this: https://www.django-rest-framework.org/api-guide/relations/#stringrelatedfield
Whatever is defined in `__str__` of Tag model will be displayed instead of id.

![Screen Shot 2020-03-11 at 10 55 07 AM](https://user-images.githubusercontent.com/33209105/76448119-10188a80-6387-11ea-9c6e-52d95e76bfb4.png)
![Screen Shot 2020-03-11 at 10 55 18 AM](https://user-images.githubusercontent.com/33209105/76448128-127ae480-6387-11ea-9b39-f26d0d7982cd.png)
